### PR TITLE
fix qreduceAssay qranges issue

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: RaggedExperiment
 Title: Representation of Sparse Experiments and Assays Across Samples
-Version: 1.7.3
+Version: 1.7.4
 Authors@R: c(
     person("Martin", "Morgan", email = "martin.morgan@roswellpark.org",
         role = c("aut", "cre")),

--- a/R/assay-functions.R
+++ b/R/assay-functions.R
@@ -247,12 +247,13 @@ qreduceAssay <-
     group <- (row - 1L) * max(col, 0) + col # 'max(col, 0)' for 0-length col
     group <- match(group, unique(group)) # 'sorted'
 
+    ugroup <- !duplicated(group)
     result <- simplifyReduce(
         unname(splitAsList(score, group)),
         unname(splitAsList(ranges, group)),
-        unname(qranges)
+        unname(qranges)[ugroup]
     )
-    group <- !duplicated(group)
+    group <- ugroup
 
     na <- as(background, class(result))
     dimnames <- list(NULL, NULL)

--- a/inst/scripts/assay-functions-Ex.R
+++ b/inst/scripts/assay-functions-Ex.R
@@ -7,8 +7,13 @@ re4 <- RaggedExperiment(GRangesList(
 query <- GRanges(c("chr1:1-14:-", "chr2:11-18:+"))
 
 weightedmean <- function(scores, ranges, qranges)
+{
     ## weighted average score per query range
-    sum(scores * width(ranges)) / sum(width(qranges))
+    ## the weight corresponds to the size of the overlap of each 
+    ## overlapping subject range with the corresponding query range  
+    isects <- pintersect(ranges, qranges)
+    sum(scores * width(isects)) / sum(width(isects))
+}
 
 qreduceAssay(re4, query, weightedmean)
 

--- a/man/assay-functions.Rd
+++ b/man/assay-functions.Rd
@@ -125,8 +125,13 @@ re4 <- RaggedExperiment(GRangesList(
 query <- GRanges(c("chr1:1-14:-", "chr2:11-18:+"))
 
 weightedmean <- function(scores, ranges, qranges)
+{
     ## weighted average score per query range
-    sum(scores * width(ranges)) / sum(width(qranges))
+    ## the weight corresponds to the size of the overlap of each 
+    ## overlapping subject range with the corresponding query range  
+    isects <- pintersect(ranges, qranges)
+    sum(scores * width(isects)) / sum(width(isects))
+}
 
 qreduceAssay(re4, query, weightedmean)
 

--- a/vignettes/RaggedExperiment.Rmd
+++ b/vignettes/RaggedExperiment.Rmd
@@ -215,7 +215,8 @@ for additional details.
 ```{r}
 weightedmean <- function(scores, ranges, qranges)
 {
-    sum(scores * width(ranges)) / sum(width(qranges))
+    isects <- pintersect(ranges, qranges)
+    sum(scores * width(isects)) / sum(width(isects))
 }
 ```
 


### PR DESCRIPTION
Fixes qreduceAssay qranges issue as described here:

https://github.com/Bioconductor/RaggedExperiment/issues/20#issue-357469794

and as discussed with @LiNk-NY   

Also updates the definition of `weightedmean` as the `simplifyReduce` function in man page and vignette.