### PR TITLE
add sparseMatrix support for compact and sparseAssay

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -22,6 +22,7 @@ Imports:
     BiocGenerics,
     GenomeInfoDb,
     IRanges,
+    Matrix,
     MatrixGenerics,
     methods,
     S4Vectors,
@@ -34,3 +35,4 @@ Suggests:
     MultiAssayExperiment
 LazyData: true
 RoxygenNote: 7.1.1
+Encoding: UTF-8

--- a/R/assay-functions.R
+++ b/R/assay-functions.R
@@ -43,18 +43,18 @@
 #' @param background A value (default NA) for the returned matrix after
 #'     \code{*Assay} operations
 #'
-#' @param Matrix logical(1) whether to return a
+#' @param sparse logical(1) whether to return a
 #'     \code{\link[Matrix]{sparseMatrix}} representation
 #'
 #' @return \code{sparseAssay()}: A matrix() with dimensions
 #'     \code{dim(x)}. Elements contain the assay value for the \emph{i}th
-#'     range and \emph{j}th sample. Use 'Matrix=TRUE' to obtain
+#'     range and \emph{j}th sample. Use 'sparse=TRUE' to obtain
 #'     a \code{\link[Matrix]{sparseMatrix}} assay representation.
 #'
 #' @export
 sparseAssay <-
     function(
-        x, i = 1, withDimnames = TRUE, background = NA_integer_, Matrix = FALSE
+        x, i = 1, withDimnames = TRUE, background = NA_integer_, sparse = FALSE
     )
 {
     i <- .assay_i(x, i)
@@ -72,7 +72,7 @@ sparseAssay <-
         row = seq_len(dim[[1L]]),
         col = rep(seq_len(dim[[2]]), lengths(.assays(x)))
     )
-    if (Matrix) {
+    if (sparse) {
         M <- Matrix::sparseMatrix(
             i = idx[, 1], j = idx[, 2], x = mcol, dims = dim
         )
@@ -90,13 +90,13 @@ sparseAssay <-
 #'
 #' @return \code{compactAssay()}: Samples with identical range are placed
 #'     in the same row. Non-disjoint ranges are NOT collapsed. Use
-#'     'Matrix=TRUE' to obtain a \code{\link[Matrix]{sparseMatrix}} assay
+#'     'sparse=TRUE' to obtain a \code{\link[Matrix]{sparseMatrix}} assay
 #'     representation.
 #'
 #' @export
 compactAssay <-
     function(
-        x, i = 1, withDimnames = TRUE, background = NA_integer_, Matrix = FALSE
+        x, i = 1, withDimnames = TRUE, background = NA_integer_, sparse = FALSE
     )
 {
     i <- .assay_i(x, i)
@@ -119,7 +119,7 @@ compactAssay <-
         col = rep(seq_len(dim[[2]]), lengths(.assays(x)))[.rowidx(x)]
     )
 
-    if (Matrix) {
+    if (sparse) {
         M <- Matrix::sparseMatrix(
             i = idx[, 1], j = idx[, 2], x = mcol,
             dims = list(length(ugr), dim[[2]])

--- a/R/coerce-functions.R
+++ b/R/coerce-functions.R
@@ -31,7 +31,7 @@
 #' @param withDimnames \code{logical(1)} default TRUE. propagate
 #'     dimnames to SummarizedExperiment.
 #'
-#' @param Matrix logical(1) whether to return a
+#' @param sparse logical(1) whether to return a
 #'     \code{\link[Matrix]{sparseMatrix}} representation
 #'
 #' @return All functions return \code{RangedSummarizedExperiment}.
@@ -39,7 +39,7 @@
 #' @return \code{sparseSummarizedExperiment} has \code{rowRanges()}
 #'     identical to the row ranges of \code{x}, and \code{assay()}
 #'     data as \code{sparseAssay()}. This is very space-inefficient
-#'     representation of ragged data. Use 'Matrix=TRUE' to obtain
+#'     representation of ragged data. Use 'sparse=TRUE' to obtain
 #'     a \code{\link[Matrix]{sparseMatrix}} assay representation.
 #'
 #' @example inst/scripts/coerce-functions-Ex.R
@@ -48,11 +48,11 @@
 #'
 #' @export
 sparseSummarizedExperiment <-
-    function(x, i = 1, withDimnames=TRUE, Matrix = FALSE)
+    function(x, i = 1, withDimnames=TRUE, sparse = FALSE)
 {
     i <- .assay_i(x, i)
     name <- assayNames(x)[[i]]
-    assay <- sparseAssay(x, i, withDimnames=withDimnames, Matrix = Matrix)
+    assay <- sparseAssay(x, i, withDimnames=withDimnames, sparse = sparse)
     assay <- setNames(list(assay), name)
 
     colData <- colData(x)
@@ -70,18 +70,18 @@ sparseSummarizedExperiment <-
 #'     identical to the row ranges of \code{x}, and \code{assay()}
 #'     data as \code{compactAssay()}. This is space-inefficient
 #'     representation of ragged data when samples are primarily
-#'     composed of different ranges. Use 'Matrix=TRUE' to obtain
+#'     composed of different ranges. Use 'sparse=TRUE' to obtain
 #'     a \code{\link[Matrix]{sparseMatrix}} assay representation.
 #'
 #' @importFrom GenomicRanges GRanges
 #'
 #' @export
 compactSummarizedExperiment <-
-    function(x, i = 1L, withDimnames=TRUE, Matrix = FALSE)
+    function(x, i = 1L, withDimnames=TRUE, sparse = FALSE)
 {
     i <- .assay_i(x, i)
     name <- assayNames(x)[[i]]
-    assay <- compactAssay(x, i, Matrix = Matrix)
+    assay <- compactAssay(x, i, sparse = sparse)
     rowRanges <- setNames(GRanges(rownames(assay)), rownames(assay))
     if (!withDimnames)
         assay <- unname(assay)

--- a/R/coerce-functions.R
+++ b/R/coerce-functions.R
@@ -31,12 +31,16 @@
 #' @param withDimnames \code{logical(1)} default TRUE. propagate
 #'     dimnames to SummarizedExperiment.
 #'
+#' @param Matrix logical(1) whether to return a
+#'     \code{\link[Matrix]{sparseMatrix}} representation
+#'
 #' @return All functions return \code{RangedSummarizedExperiment}.
 #'
 #' @return \code{sparseSummarizedExperiment} has \code{rowRanges()}
 #'     identical to the row ranges of \code{x}, and \code{assay()}
 #'     data as \code{sparseAssay()}. This is very space-inefficient
-#'     representation of ragged data.
+#'     representation of ragged data. Use 'Matrix=TRUE' to obtain
+#'     a \code{\link[Matrix]{sparseMatrix}} assay representation.
 #'
 #' @example inst/scripts/coerce-functions-Ex.R
 #'
@@ -44,11 +48,11 @@
 #'
 #' @export
 sparseSummarizedExperiment <-
-    function(x, i = 1, withDimnames=TRUE)
+    function(x, i = 1, withDimnames=TRUE, Matrix = FALSE)
 {
     i <- .assay_i(x, i)
     name <- assayNames(x)[[i]]
-    assay <- sparseAssay(x, i, withDimnames=withDimnames)
+    assay <- sparseAssay(x, i, withDimnames=withDimnames, Matrix = Matrix)
     assay <- setNames(list(assay), name)
 
     colData <- colData(x)
@@ -66,17 +70,18 @@ sparseSummarizedExperiment <-
 #'     identical to the row ranges of \code{x}, and \code{assay()}
 #'     data as \code{compactAssay()}. This is space-inefficient
 #'     representation of ragged data when samples are primarily
-#'     composed of different ranges.
+#'     composed of different ranges. Use 'Matrix=TRUE' to obtain
+#'     a \code{\link[Matrix]{sparseMatrix}} assay representation.
 #'
 #' @importFrom GenomicRanges GRanges
 #'
 #' @export
 compactSummarizedExperiment <-
-    function(x, i = 1L, withDimnames=TRUE)
+    function(x, i = 1L, withDimnames=TRUE, Matrix = FALSE)
 {
     i <- .assay_i(x, i)
     name <- assayNames(x)[[i]]
-    assay <- compactAssay(x, i)
+    assay <- compactAssay(x, i, Matrix = Matrix)
     rowRanges <- setNames(GRanges(rownames(assay)), rownames(assay))
     if (!withDimnames)
         assay <- unname(assay)

--- a/man/assay-functions.Rd
+++ b/man/assay-functions.Rd
@@ -13,7 +13,7 @@ sparseAssay(
   i = 1,
   withDimnames = TRUE,
   background = NA_integer_,
-  Matrix = FALSE
+  sparse = FALSE
 )
 
 compactAssay(
@@ -21,7 +21,7 @@ compactAssay(
   i = 1,
   withDimnames = TRUE,
   background = NA_integer_,
-  Matrix = FALSE
+  sparse = FALSE
 )
 
 disjoinAssay(
@@ -56,7 +56,7 @@ are always manufactured for \code{compactAssay()} and
 \item{background}{A value (default NA) for the returned matrix after
 \code{*Assay} operations}
 
-\item{Matrix}{logical(1) whether to return a
+\item{sparse}{logical(1) whether to return a
 \code{\link[Matrix]{sparseMatrix}} representation}
 
 \item{simplifyDisjoin}{A \code{function} / functional operating on a
@@ -110,12 +110,12 @@ is to occur.}
 \value{
 \code{sparseAssay()}: A matrix() with dimensions
     \code{dim(x)}. Elements contain the assay value for the \emph{i}th
-    range and \emph{j}th sample. Use 'Matrix=TRUE' to obtain
+    range and \emph{j}th sample. Use 'sparse=TRUE' to obtain
     a \code{\link[Matrix]{sparseMatrix}} assay representation.
 
 \code{compactAssay()}: Samples with identical range are placed
     in the same row. Non-disjoint ranges are NOT collapsed. Use
-    'Matrix=TRUE' to obtain a \code{\link[Matrix]{sparseMatrix}} assay
+    'sparse=TRUE' to obtain a \code{\link[Matrix]{sparseMatrix}} assay
     representation.
 
 \code{disjoinAssay()}: A matrix with number of rows equal

--- a/man/assay-functions.Rd
+++ b/man/assay-functions.Rd
@@ -8,9 +8,21 @@
 \alias{qreduceAssay}
 \title{Create simplified representation of ragged assay data.}
 \usage{
-sparseAssay(x, i = 1, withDimnames = TRUE, background = NA_integer_)
+sparseAssay(
+  x,
+  i = 1,
+  withDimnames = TRUE,
+  background = NA_integer_,
+  Matrix = FALSE
+)
 
-compactAssay(x, i = 1, withDimnames = TRUE, background = NA_integer_)
+compactAssay(
+  x,
+  i = 1,
+  withDimnames = TRUE,
+  background = NA_integer_,
+  Matrix = FALSE
+)
 
 disjoinAssay(
   x,
@@ -43,6 +55,9 @@ are always manufactured for \code{compactAssay()} and
 
 \item{background}{A value (default NA) for the returned matrix after
 \code{*Assay} operations}
+
+\item{Matrix}{logical(1) whether to return a
+\code{\link[Matrix]{sparseMatrix}} representation}
 
 \item{simplifyDisjoin}{A \code{function} / functional operating on a
     \code{*List}, where the elements of the list are all within-sample
@@ -95,10 +110,13 @@ is to occur.}
 \value{
 \code{sparseAssay()}: A matrix() with dimensions
     \code{dim(x)}. Elements contain the assay value for the \emph{i}th
-    range and \emph{j}th sample.
+    range and \emph{j}th sample. Use 'Matrix=TRUE' to obtain
+    a \code{\link[Matrix]{sparseMatrix}} assay representation.
 
 \code{compactAssay()}: Samples with identical range are placed
-    in the same row. Non-disjoint ranges are NOT collapsed.
+    in the same row. Non-disjoint ranges are NOT collapsed. Use
+    'Matrix=TRUE' to obtain a \code{\link[Matrix]{sparseMatrix}} assay
+    representation.
 
 \code{disjoinAssay()}: A matrix with number of rows equal
     to number of disjoint ranges across all samples. Elements of

--- a/man/coerce-functions.Rd
+++ b/man/coerce-functions.Rd
@@ -8,9 +8,9 @@
 \title{Create SummarizedExperiment representations by transforming
     ragged assays to rectangular form.}
 \usage{
-sparseSummarizedExperiment(x, i = 1, withDimnames = TRUE, Matrix = FALSE)
+sparseSummarizedExperiment(x, i = 1, withDimnames = TRUE, sparse = FALSE)
 
-compactSummarizedExperiment(x, i = 1L, withDimnames = TRUE, Matrix = FALSE)
+compactSummarizedExperiment(x, i = 1L, withDimnames = TRUE, sparse = FALSE)
 
 disjoinSummarizedExperiment(x, simplifyDisjoin, i = 1L, withDimnames = TRUE)
 
@@ -31,7 +31,7 @@ qreduceSummarizedExperiment(
 \item{withDimnames}{\code{logical(1)} default TRUE. propagate
 dimnames to SummarizedExperiment.}
 
-\item{Matrix}{logical(1) whether to return a
+\item{sparse}{logical(1) whether to return a
 \code{\link[Matrix]{sparseMatrix}} representation}
 
 \item{simplifyDisjoin}{\code{function} of 1 argument, used to
@@ -49,14 +49,14 @@ All functions return \code{RangedSummarizedExperiment}.
 \code{sparseSummarizedExperiment} has \code{rowRanges()}
     identical to the row ranges of \code{x}, and \code{assay()}
     data as \code{sparseAssay()}. This is very space-inefficient
-    representation of ragged data. Use 'Matrix=TRUE' to obtain
+    representation of ragged data. Use 'sparse=TRUE' to obtain
     a \code{\link[Matrix]{sparseMatrix}} assay representation.
 
 \code{compactSummarizedExperiment} has \code{rowRanges()}
     identical to the row ranges of \code{x}, and \code{assay()}
     data as \code{compactAssay()}. This is space-inefficient
     representation of ragged data when samples are primarily
-    composed of different ranges. Use 'Matrix=TRUE' to obtain
+    composed of different ranges. Use 'sparse=TRUE' to obtain
     a \code{\link[Matrix]{sparseMatrix}} assay representation.
 
 \code{disjoinSummarizedExperiment} has \code{rowRanges()}

--- a/man/coerce-functions.Rd
+++ b/man/coerce-functions.Rd
@@ -8,9 +8,9 @@
 \title{Create SummarizedExperiment representations by transforming
     ragged assays to rectangular form.}
 \usage{
-sparseSummarizedExperiment(x, i = 1, withDimnames = TRUE)
+sparseSummarizedExperiment(x, i = 1, withDimnames = TRUE, Matrix = FALSE)
 
-compactSummarizedExperiment(x, i = 1L, withDimnames = TRUE)
+compactSummarizedExperiment(x, i = 1L, withDimnames = TRUE, Matrix = FALSE)
 
 disjoinSummarizedExperiment(x, simplifyDisjoin, i = 1L, withDimnames = TRUE)
 
@@ -31,6 +31,9 @@ qreduceSummarizedExperiment(
 \item{withDimnames}{\code{logical(1)} default TRUE. propagate
 dimnames to SummarizedExperiment.}
 
+\item{Matrix}{logical(1) whether to return a
+\code{\link[Matrix]{sparseMatrix}} representation}
+
 \item{simplifyDisjoin}{\code{function} of 1 argument, used to
 transform assays. See \code{\link{assay-functions}}.}
 
@@ -46,13 +49,15 @@ All functions return \code{RangedSummarizedExperiment}.
 \code{sparseSummarizedExperiment} has \code{rowRanges()}
     identical to the row ranges of \code{x}, and \code{assay()}
     data as \code{sparseAssay()}. This is very space-inefficient
-    representation of ragged data.
+    representation of ragged data. Use 'Matrix=TRUE' to obtain
+    a \code{\link[Matrix]{sparseMatrix}} assay representation.
 
 \code{compactSummarizedExperiment} has \code{rowRanges()}
     identical to the row ranges of \code{x}, and \code{assay()}
     data as \code{compactAssay()}. This is space-inefficient
     representation of ragged data when samples are primarily
-    composed of different ranges.
+    composed of different ranges. Use 'Matrix=TRUE' to obtain
+    a \code{\link[Matrix]{sparseMatrix}} assay representation.
 
 \code{disjoinSummarizedExperiment} has \code{rowRanges()}
     identical to the disjoint row ranges of \code{x},

--- a/tests/testthat/test_assay-functions.R
+++ b/tests/testthat/test_assay-functions.R
@@ -22,9 +22,9 @@ test_that("sparseAssay() works", {
     M0 <- Matrix::sparseMatrix(
         i = c(1, 2, 3, 4), j = c(1, 1, 2, 2), x = 1:4, dims = c(4, 2)
     )
-    expect_identical(sparseAssay(re, Matrix = TRUE, withDimnames = FALSE), M0)
+    expect_identical(sparseAssay(re, sparse = TRUE, withDimnames = FALSE), M0)
     dimnames(M0) <- dimnames(m0)
-    expect_identical(sparseAssay(re, Matrix = TRUE), M0)
+    expect_identical(sparseAssay(re, sparse = TRUE), M0)
 })
 
 
@@ -49,9 +49,9 @@ test_that("compactAssay() works", {
     M0 <- Matrix::sparseMatrix(
         i = c(1, 2, 1, 3), j = c(1, 1, 2, 2), x = 1:4, dims = c(3, 2)
     )
-    expect_identical(compactAssay(re, Matrix = TRUE, withDimnames = FALSE), M0)
+    expect_identical(compactAssay(re, sparse = TRUE, withDimnames = FALSE), M0)
     dimnames(M0) <- dimnames(m0)
-    expect_identical(compactAssay(re, Matrix = TRUE), M0)
+    expect_identical(compactAssay(re, sparse = TRUE), M0)
 
     ridx <- 3:1
     expect_identical(compactAssay(re[ridx,]), m0[1:2,])


### PR DESCRIPTION
This allows users a more space-efficient representation of sparse matrices. 